### PR TITLE
Improve display of element sections

### DIFF
--- a/src/components/attributes/AttributeListComponent.tsx
+++ b/src/components/attributes/AttributeListComponent.tsx
@@ -22,6 +22,16 @@ import StoryCircleStageAttributeComponent from "./types/StoryCircleStageAttribut
 import StrengthsAttributeComponent from "./types/StrengthsAttributeComponent";
 import WeaknessesAttributeComponent from "./types/WeaknessesAttributeComponent";
 
+const ATTRIBUTES_TO_NOT_SHOW = [
+	AttributeComponentType.Description,
+	AttributeComponentType.StoryCircle,
+	AttributeComponentType.Kishotenketsu,
+	AttributeComponentType.Duration,
+	AttributeComponentType.Parent,
+	AttributeComponentType.Conflict,
+	AttributeComponentType.SensoryImprint,
+];
+
 export default function AttributeListComponent({
 	element,
 	isEditable,
@@ -31,6 +41,9 @@ export default function AttributeListComponent({
 }): React.ReactElement {
 	const { t } = useTranslation();
 
+	const attributes = element.attributes.filter((attribute) => attribute.isSet && !ATTRIBUTES_TO_NOT_SHOW.contains(attribute.type));
+	if (attributes.length === 0) return null;
+
 	return (
 		<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] relative p-3">
 			<div>
@@ -39,19 +52,7 @@ export default function AttributeListComponent({
 				</h2>
 			</div>
 			<div>
-				{element.attributes.map((attribute: AttributeInterface, index: number) => {
-					if (
-						attribute.type === AttributeComponentType.Description ||
-						attribute.type === AttributeComponentType.StoryCircle ||
-						attribute.type === AttributeComponentType.Kishotenketsu ||
-						attribute.type === AttributeComponentType.Duration ||
-						attribute.type === AttributeComponentType.Parent ||
-						attribute.type === AttributeComponentType.Conflict ||
-						attribute.type === AttributeComponentType.SensoryImprint ||
-						!attribute.isSet
-					)
-						return null;
-
+				{attributes.map((attribute: AttributeInterface, index: number) => {
 					let attributeComponent;
 
 					switch (attribute.type) {

--- a/src/components/elements/AdventureComponent.tsx
+++ b/src/components/elements/AdventureComponent.tsx
@@ -13,7 +13,7 @@ import HeaderComponent from "../headers/HeaderComponent";
 import HierarchyComponent from "../hierarchies/HierarchyComponent";
 import ImageCarouselComponent from "../images/ImageCarouselComponent";
 import KishotenketsuComponent from "../kishotenketsu/KishotenketsuComponent";
-import RelationshipsComponent from "../relationships/RelationshipsComponent";
+import RelationshipsContainerComponent from "../relationships/RelationshipsContainerComponent";
 import TasksContainerComponent from "../tasks/TasksContainerComponent";
 
 export default function AdventureComponent({
@@ -76,11 +76,7 @@ export default function AdventureComponent({
 					isDraggable={!isInPopover}
 				/>
 				{!isInPopover && <TasksContainerComponent element={element} />}
-				{isInPopover === false && element.relationships.length > 0 && (
-					<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">
-						<RelationshipsComponent element={element} />
-					</div>
-				)}
+				{isInPopover === false && <RelationshipsContainerComponent element={element} /> }
 			</div>
 		</>
 	);

--- a/src/components/elements/ChapterComponent.tsx
+++ b/src/components/elements/ChapterComponent.tsx
@@ -12,7 +12,7 @@ import BannerComponent from "../headers/BannerComponent";
 import HeaderComponent from "../headers/HeaderComponent";
 import ImageCarouselComponent from "../images/ImageCarouselComponent";
 import KishotenketsuComponent from "../kishotenketsu/KishotenketsuComponent";
-import RelationshipsComponent from "../relationships/RelationshipsComponent";
+import RelationshipsContainerComponent from "../relationships/RelationshipsContainerComponent";
 import TasksContainerComponent from "../tasks/TasksContainerComponent";
 
 export default function ChapterComponent({
@@ -65,11 +65,8 @@ export default function ChapterComponent({
 					</div>
 				)}
 				{!isInPopover && <TasksContainerComponent element={element} />}
-				{isInPopover === false && element.relationships.length > 0 && (
-					<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">
-						<RelationshipsComponent element={element} />
-					</div>
-				)}
+				{isInPopover === false && <RelationshipsContainerComponent element={element} /> }
+
 			</div>
 		</>
 	);

--- a/src/components/elements/EventComponent.tsx
+++ b/src/components/elements/EventComponent.tsx
@@ -6,7 +6,7 @@ import DescriptionAttributeComponent from "../attributes/types/DescriptionAttrib
 import BannerComponent from "../headers/BannerComponent";
 import HeaderComponent from "../headers/HeaderComponent";
 import ImageCarouselComponent from "../images/ImageCarouselComponent";
-import RelationshipsComponent from "../relationships/RelationshipsComponent";
+import RelationshipsContainerComponent from "../relationships/RelationshipsContainerComponent";
 import TasksContainerComponent from "../tasks/TasksContainerComponent";
 
 export default function EventComponent({
@@ -39,11 +39,7 @@ export default function EventComponent({
 					</div>
 				)}
 				{!isInPopover && <TasksContainerComponent element={element} />}
-				{isInPopover === false && element.relationships.length > 0 && (
-					<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">
-						<RelationshipsComponent element={element} />
-					</div>
-				)}
+				{isInPopover === false && <RelationshipsContainerComponent element={element} /> }
 			</div>
 		</>
 	);

--- a/src/components/elements/SceneComponent.tsx
+++ b/src/components/elements/SceneComponent.tsx
@@ -11,7 +11,7 @@ import SensoryImprintAttributeComponent from "../attributes/types/SensoryImprint
 import HeaderComponent from "../headers/HeaderComponent";
 import ImageCarouselComponent from "../images/ImageCarouselComponent";
 import ImageComponent from "../images/ImageComponent";
-import RelationshipsComponent from "../relationships/RelationshipsComponent";
+import RelationshipsContainerComponent from "../relationships/RelationshipsContainerComponent";
 import TasksContainerComponent from "../tasks/TasksContainerComponent";
 
 export default function SceneComponent({
@@ -61,11 +61,7 @@ export default function SceneComponent({
 					</div>
 				)}
 				{!isInPopover && <TasksContainerComponent element={element} />}
-				{isInPopover === false && element.relationships.length > 0 && (
-					<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">
-						<RelationshipsComponent element={element} />
-					</div>
-				)}
+				{isInPopover === false && <RelationshipsContainerComponent element={element} /> }
 			</div>
 		</>
 	);

--- a/src/components/elements/SessionComponent.tsx
+++ b/src/components/elements/SessionComponent.tsx
@@ -14,7 +14,7 @@ import HierarchyComponent from "../hierarchies/HierarchyComponent";
 import ImageCarouselComponent from "../images/ImageCarouselComponent";
 import ImageComponent from "../images/ImageComponent";
 import KishotenketsuComponent from "../kishotenketsu/KishotenketsuComponent";
-import RelationshipsComponent from "../relationships/RelationshipsComponent";
+import RelationshipsContainerComponent from "../relationships/RelationshipsContainerComponent";
 import TasksContainerComponent from "../tasks/TasksContainerComponent";
 
 export default function SessionComponent({
@@ -78,11 +78,7 @@ export default function SessionComponent({
 					</div>
 				)}
 				{!isInPopover && <TasksContainerComponent element={element} />}
-				{isInPopover === false && element.relationships.length > 0 && (
-					<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3 m-3">
-						<RelationshipsComponent element={element} />
-					</div>
-				)}
+				{isInPopover === false && <RelationshipsContainerComponent element={element} /> }
 			</div>
 		</>
 	);

--- a/src/components/elements/SubplotComponent.tsx
+++ b/src/components/elements/SubplotComponent.tsx
@@ -9,7 +9,7 @@ import StoryCircleAttributeComponent from "../attributes/types/StoryCircleAttrib
 import HeaderComponent from "../headers/HeaderComponent";
 import ImageCarouselComponent from "../images/ImageCarouselComponent";
 import ImageComponent from "../images/ImageComponent";
-import RelationshipsComponent from "../relationships/RelationshipsComponent";
+import RelationshipsContainerComponent from "../relationships/RelationshipsContainerComponent";
 import TasksContainerComponent from "../tasks/TasksContainerComponent";
 
 export default function SubplotComponent({
@@ -53,11 +53,7 @@ export default function SubplotComponent({
 					</div>
 				)}
 				{!isInPopover && <TasksContainerComponent element={element} />}
-				{isInPopover === false && element.relationships.length > 0 && (
-					<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">
-						<RelationshipsComponent element={element} />
-					</div>
-				)}
+				{isInPopover === false && <RelationshipsContainerComponent element={element} /> }
 			</div>
 		</>
 	);

--- a/src/components/groups/MainV1Component.tsx
+++ b/src/components/groups/MainV1Component.tsx
@@ -1,4 +1,5 @@
 import { ElementType } from "@/data/enums/ElementType";
+import { ElementInterface } from "@/data/interfaces/ElementInterface";
 import * as React from "react";
 import { AttributeType } from "src/data/enums/AttributeType";
 import AttributeListComponent from "../attributes/AttributeListComponent";
@@ -8,14 +9,14 @@ import SensoryImprintAttributeComponent from "../attributes/types/SensoryImprint
 import HeaderComponent from "../headers/HeaderComponent";
 import ImageCarouselComponent from "../images/ImageCarouselComponent";
 import ImageComponent from "../images/ImageComponent";
-import RelationshipsComponent from "../relationships/RelationshipsComponent";
+import RelationshipsContainerComponent from "../relationships/RelationshipsContainerComponent";
 import TasksContainerComponent from "../tasks/TasksContainerComponent";
 
 export default function MainV1Component({
 	element,
 	isInPopover,
 }: {
-	element: any;
+	element: ElementInterface;
 	isInPopover: boolean;
 }): React.ReactElement {
 	return (
@@ -66,11 +67,7 @@ export default function MainV1Component({
 				</div>
 			)}
 			{!isInPopover && <TasksContainerComponent element={element} />}
-			{isInPopover === false && element.relationships.length > 0 && (
-				<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">
-					<RelationshipsComponent element={element} />
-				</div>
-			)}
+			{isInPopover === false && <RelationshipsContainerComponent element={element} /> }
 		</>
 	);
 }

--- a/src/components/options/OptionsViewComponent.tsx
+++ b/src/components/options/OptionsViewComponent.tsx
@@ -1,3 +1,4 @@
+import { NewTaskController } from "@/controllers/NewTaskController";
 import { useApp } from "@/hooks/useApp";
 import { FileUploadService } from "@/services/FileUploadService";
 import { App } from "obsidian";
@@ -64,6 +65,11 @@ export default function OptionsViewComponent({ element }: { element: ElementInte
 	const addRelationship = () => {
 		const relationshipModal = new NewRelationshipController(app, api, element);
 		relationshipModal.open();
+	};
+
+	const addTask = () => {
+		const taskModal = new NewTaskController(app, api, element);
+		taskModal.open();
 	};
 
 	const openGallery = () => {
@@ -150,6 +156,12 @@ export default function OptionsViewComponent({ element }: { element: ElementInte
 						{t("options.wizard")}
 					</div>
 				)}
+				<div
+					className="cursor-pointer text-[--text-accent] hover:text-[--text-accent-hover] list-disc list-inside pl-2 pr-2 pt-1 pb-1 border border-transparent hover:bg-[--background-primary-alt] hover:border-[--background-modifier-border] rounded-lg"
+					onClick={addTask}
+				>
+					{t("create.add", { context: "task" })}
+				</div>
 				{element.type !== ElementType.Campaign && (
 					<div
 						className="cursor-pointer text-[--text-accent] hover:text-[--text-accent-hover] list-disc list-inside pl-2 pr-2 pt-1 pb-1 border border-transparent hover:bg-[--background-primary-alt] hover:border-[--background-modifier-border] rounded-lg"

--- a/src/components/relationships/RelationshipsComponent.tsx
+++ b/src/components/relationships/RelationshipsComponent.tsx
@@ -5,7 +5,7 @@ import { ElementInterface } from "src/data/interfaces/ElementInterface";
 import RelationshipListComponent from "./RelationshipListComponent";
 
 export default function RelationshipsComponent({ element }: { element: ElementInterface }): React.ReactElement {
-	if (element.relationships.length === 0) return null;
+	if (element.relationshipsToDisplay.length === 0) return null;
 
 	const { t } = useTranslation();
 

--- a/src/components/relationships/RelationshipsContainerComponent.tsx
+++ b/src/components/relationships/RelationshipsContainerComponent.tsx
@@ -1,0 +1,18 @@
+import { RpgManagerInterface } from "@/RpgManagerInterface";
+import { useApi } from "@/hooks/useApi";
+import * as React from "react";
+import { ElementInterface } from "src/data/interfaces/ElementInterface";
+import RelationshipsComponent from "./RelationshipsComponent";
+
+export default function RelationshipsContainerComponent({ element }: { element: ElementInterface }): React.ReactElement {
+	const api: RpgManagerInterface = useApi();
+
+	if (!api.settings.showRelationships[element.type]) return null;
+	if (element.relationships.length === 0) return null;
+
+	return (
+		<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">
+			<RelationshipsComponent element={element} />
+		</div>
+	);
+}

--- a/src/components/relationships/RelationshipsContainerComponent.tsx
+++ b/src/components/relationships/RelationshipsContainerComponent.tsx
@@ -8,7 +8,7 @@ export default function RelationshipsContainerComponent({ element }: { element: 
 	const api: RpgManagerInterface = useApi();
 
 	if (!api.settings.showRelationships[element.type]) return null;
-	if (element.relationships.length === 0) return null;
+	if (element.relationshipsToDisplay.length === 0) return null;
 
 	return (
 		<div className="rounded-lg border border-[--background-modifier-border] bg-[--background-primary] p-3">

--- a/src/components/tasks/NewTaskComponent.tsx
+++ b/src/components/tasks/NewTaskComponent.tsx
@@ -13,7 +13,7 @@ export default function NewTaskComponent({
 }: {
 	element: ElementInterface;
 	onTaskCreation: (task: TaskInterface) => void;
-	onCancel: (showNewTask: boolean) => void;
+	onCancel?: (showNewTask: boolean) => void;
 }): React.ReactElement {
 	const { t } = useTranslation();
 	const api: RpgManagerInterface = useApi();
@@ -54,9 +54,9 @@ export default function NewTaskComponent({
 				</div>
 			</div>
 			<div className="flex justify-end w-full text-xs">
-				<button className="rpgm-secondary pl-3 pr-3 mr-3" onClick={() => onCancel(false)}>
+				{onCancel && <button className="rpgm-secondary pl-3 pr-3 mr-3" onClick={() => onCancel(false)}>
 					{t("buttons.cancel")}
-				</button>
+				</button>}
 				<button className="rpgm-primary pl-3 pr-3" onClick={handleCreateNewTask}>
 					{t("create.add", { context: "task" })}
 				</button>

--- a/src/components/tasks/TasksContainerComponent.tsx
+++ b/src/components/tasks/TasksContainerComponent.tsx
@@ -18,6 +18,8 @@ export default function TasksContainerComponent({ element }: { element: ElementI
 	const [viewTasks, setViewTasks] = React.useState<boolean>(true);
 	const [viewType, setViewType] = React.useState<"own" | "assigned" | "all">(tasks.length > 0 ? "assigned" : "own");
 
+	if (!api.settings.showTasks[element.type]) return null;
+
 	if (viewType === "own") {
 		tasks = element.tasks;
 	} else if (viewType === "all") {

--- a/src/components/tasks/TasksContainerComponent.tsx
+++ b/src/components/tasks/TasksContainerComponent.tsx
@@ -19,6 +19,7 @@ export default function TasksContainerComponent({ element }: { element: ElementI
 	const [viewType, setViewType] = React.useState<"own" | "assigned" | "all">(tasks.length > 0 ? "assigned" : "own");
 
 	if (!api.settings.showTasks[element.type]) return null;
+	if (tasks.length === 0 && element.tasks.length === 0) return null;
 
 	if (viewType === "own") {
 		tasks = element.tasks;

--- a/src/controllers/NewTaskController.ts
+++ b/src/controllers/NewTaskController.ts
@@ -1,0 +1,53 @@
+import NewTaskComponent from "@/components/tasks/NewTaskComponent";
+import { ApiContext } from "@/contexts/ApiContext";
+import { AppContext } from "@/contexts/AppContext";
+import { RpgManagerCodeblockService } from "@/services/RpgManagerCodeblockService";
+import { TaskInterface } from "@/services/taskService/interfaces/TaskInterface";
+import { App, Modal } from "obsidian";
+import { createElement } from "react";
+import { Root, createRoot } from "react-dom/client";
+import { RpgManagerInterface } from "src/RpgManagerInterface";
+import { ElementInterface } from "src/data/interfaces/ElementInterface";
+
+
+export class NewTaskController extends Modal {
+	constructor(
+		private _app: App,
+		private _api: RpgManagerInterface,
+		private _element?: ElementInterface | undefined,
+	) {
+		super(_app);
+	}
+	onOpen() {
+		super.onOpen();
+
+		const { contentEl } = this;
+		contentEl.empty();
+		const root: Root = createRoot(contentEl);
+		this.modalEl.style.width = "var(--modal-max-width)";
+
+		const handleSave = (task: TaskInterface) => {
+			const codeblockService = new RpgManagerCodeblockService(this._app, this._api, this._element.file);
+			codeblockService.addOrUpdateTask(task);
+			this.close();
+		};
+
+		const creationComponent = createElement(NewTaskComponent, {
+			element: this._element,
+			onTaskCreation: handleSave,
+		});
+		const reactComponent = createElement(
+			AppContext.Provider,
+			{ value: this._app },
+			createElement(ApiContext.Provider, { value: this._api }, creationComponent)
+		);
+
+		root.render(reactComponent);
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+		super.onClose();
+	}
+}

--- a/src/data/classes/Element.ts
+++ b/src/data/classes/Element.ts
@@ -160,6 +160,12 @@ export class Element implements ElementInterface {
 		this._relationships = value;
 	}
 
+	get relationshipsToDisplay(): RelationshipInterface[] {
+		return this._relationships.filter((relationship) =>
+			!([ElementType.Campaign, ElementType.Session, ElementType.Scene].contains(relationship.component.type))
+		);
+	}
+
 	get campaignPath(): string | undefined {
 		return this._rpgManagerBlock.id.campaign;
 	}

--- a/src/data/interfaces/ElementInterface.ts
+++ b/src/data/interfaces/ElementInterface.ts
@@ -23,6 +23,7 @@ export interface ElementInterface {
 	get positionInParent(): number | undefined;
 	get relationships(): RelationshipInterface[];
 	set relationships(value: RelationshipInterface[]);
+	get relationshipsToDisplay(): RelationshipInterface[];
 	get version(): number;
 	get path(): string;
 	get name(): string;

--- a/src/services/UpdaterService/components/UpdaterComponent.tsx
+++ b/src/services/UpdaterService/components/UpdaterComponent.tsx
@@ -1,5 +1,6 @@
 import { RpgManagerInterface } from "@/RpgManagerInterface";
 import MarkdownComponent from "@/components/markdowns/MarkdownComponent";
+import { ElementType } from "@/data/enums/ElementType";
 import { useApi } from "@/hooks/useApi";
 import { useApp } from "@/hooks/useApp";
 import { RpgManagerSettingsInterface } from "@/settings/RpgManagerSettings";
@@ -39,6 +40,12 @@ function Upgrading(): React.ReactElement {
 				version: api.version,
 				customAttributes: [],
 				forceFullWidth: false,
+				showTasks: Object.values(ElementType).reduce(
+					(acc, element) => ({...acc, [element]: true}), {} as Record<ElementType, boolean>
+				),
+				showRelationships: Object.values(ElementType).reduce(
+					(acc, element) => ({...acc, [element]: true}), {} as Record<ElementType, boolean>
+				),
 			};
 			(api as unknown as Plugin).saveData(settings);
 

--- a/src/settings/RpgManagerSettings.ts
+++ b/src/settings/RpgManagerSettings.ts
@@ -1,3 +1,4 @@
+import { ElementType } from "@/data/enums/ElementType";
 import { AttributeInterface } from "@/data/interfaces/AttributeInterface";
 import { App, Plugin, PluginSettingTab, Setting, TAbstractFile, TFolder } from "obsidian";
 import { RpgManagerInterface } from "src/RpgManagerInterface";
@@ -11,6 +12,8 @@ export interface RpgManagerSettingsInterface {
 	version: string;
 	customAttributes: AttributeInterface[];
 	forceFullWidth: boolean;
+	showTasks: Record<ElementType, boolean>;
+	showRelationships: Record<ElementType, boolean>;
 }
 
 export type PartialSettings = Partial<RpgManagerSettingsInterface>;
@@ -24,6 +27,12 @@ export const rpgManagerDefaultSettings: RpgManagerSettingsInterface = {
 	version: "0.0.0",
 	customAttributes: [],
 	forceFullWidth: true,
+	showTasks: Object.values(ElementType).reduce(
+		(acc, element) => ({...acc, [element]: true}), {} as Record<ElementType, boolean>
+	),
+	showRelationships: Object.values(ElementType).reduce(
+		(acc, element) => ({...acc, [element]: true}), {} as Record<ElementType, boolean>
+	),
 };
 
 export class RpgManagerSettings extends PluginSettingTab {
@@ -127,6 +136,31 @@ export class RpgManagerSettings extends PluginSettingTab {
 					await this.saveSettings({ useSceneAnalyser: value });
 				});
 			});
+
+		containerEl.createEl("h3", { text: "Elements", cls: "mt-3" });
+		const ElementSettingsIntro = containerEl.createEl("p");
+		ElementSettingsIntro.appendText("Element options. ");
+
+		Object.entries(ElementType).forEach(([elementKey, elementValue]) => {
+			containerEl.createEl("h2", { text: elementKey, cls: "mt-3" });
+			new Setting(containerEl)
+				.setName(`Show ${elementKey} tasks section`)
+				.setDesc(`Toggle visibility for the Tasks section for ${elementKey} elements. `)
+				.addToggle((toggle) => {
+					toggle.setValue(this._plugin.settings.showTasks[(elementValue as ElementType)]).onChange(async (value) => {
+						await this.saveSettings({ showTasks: {...this._plugin.settings.showTasks, [elementValue]: value} });
+					});
+				});
+
+			new Setting(containerEl)
+				.setName(`Show ${elementKey} relationships section`)
+				.setDesc(`Toggle visibility for the Relationships section for ${elementKey} elements. `)
+				.addToggle((toggle) => {
+					toggle.setValue(this._plugin.settings.showRelationships[(elementValue as ElementType)]).onChange(async (value) => {
+						await this.saveSettings({ showRelationships: {...this._plugin.settings.showRelationships, [elementValue]: value} });
+					});
+				});
+		});
 
 		containerEl.createEl("h3", { text: "ChatGPT", cls: "mt-3" });
 		const ChatGPT = containerEl.createEl("p");


### PR DESCRIPTION
I was looking at using this plugin and ran across the same problem described in #330 (mainly I don't use the tasks but found the empty card to be taking up precious screen real estate). I set out to fix this problem for myself but thought it might be a good idea to contribute what I've done back to the codebase but as I was tidying up the code I realised that what I had implemented may not fit the current design philosophy.

I started changing/adding many things and eventually decided to pause and ask for clarification here!

Changes I've currently made:
- Added settings to toggle task and relationship card visibility for each element type
  - This is non-destructive in that no tasks/relationships are deleted (so they will still appear in searches)
- Made the attribute card not display for an element if it has no attributes to display
- Made the relationship card not display for an element if it has no relationships to display
- Added the ability to add a task via the options pane
- Made the task card not display for an element if it has no relationships to display

I think I am leaning towards removing the settings since just having the cards not display if they are empty already fix the "empty cards take up room" problem.