### PR TITLE
Added support for locally-hosted ollama LLM instead of chatgpt

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "rpg-manager",
 	"name": "RPG Manager",
-	"version": "4.1.14",
+	"version": "4.1.15-1",
 	"minAppVersion": "1.4.0",
 	"description": "Manage your Tabletop Role Playing Game Campaigns in Obsidian",
 	"author": "Carlo Nicora",

--- a/src/components/attributes/types/SensoryImprintAttributeComponent.tsx
+++ b/src/components/attributes/types/SensoryImprintAttributeComponent.tsx
@@ -51,7 +51,7 @@ function EditComponent({
 
 	let chatGpt: ChatGptNonPlayerCharacterModel | undefined = undefined;
 
-	if (api.settings.chatGptKey !== undefined && api.settings.chatGptKey !== "") {
+	if (api.settings.hasLLM) {
 		chatGpt = new ChatGptNonPlayerCharacterModel(
 			api,
 			element.type === ElementType.Campaign ? element : element.campaign,

--- a/src/components/wizards/npcs/NonPlayerCharacterWizardComponent.tsx
+++ b/src/components/wizards/npcs/NonPlayerCharacterWizardComponent.tsx
@@ -218,7 +218,7 @@ export default function NonPlayerCharacterWizardComponent({
 		chatGpt.current.weaknesses = weaknesses.join(", ");
 	};
 
-	if (api.settings.chatGptKey !== undefined && api.settings.chatGptKey !== "" && !chatGpt.current) {
+	if (api.settings.hasLLM && !chatGpt.current) {
 		chatGpt.current = new ChatGptNonPlayerCharacterModel(api, element?.campaign ?? campaign, element?.name ?? name);
 	}
 
@@ -259,7 +259,7 @@ export default function NonPlayerCharacterWizardComponent({
 	const [step, setStep] = React.useState(1);
 
 	const updateStep = (newStep: number) => {
-		if (api.settings.chatGptKey !== undefined && api.settings.chatGptKey !== "") {
+		if (api.settings.hasLLM) {
 			setCurrentChatGPT();
 		}
 
@@ -334,7 +334,7 @@ export default function NonPlayerCharacterWizardComponent({
 				<button className="rpgm-danger pl-3 pr-3 mr-6" onClick={() => close()}>
 					{t("buttons.cancel")}
 				</button>
-				{api.settings.chatGptKey !== undefined && api.settings.chatGptKey !== "" && chatGpt.current && step > 2 && (
+				{api.settings.hasLLM && chatGpt.current && step > 2 && (
 					<button className="rpgm-secondary pl-3 pr-3 mr-6" onClick={() => createAutomatically()}>
 						{t("wizards.npc.create")}
 					</button>

--- a/src/services/ChatGptService/ChatGptService.ts
+++ b/src/services/ChatGptService/ChatGptService.ts
@@ -51,10 +51,12 @@ Each option should be qualitative, not a short sentence and will allow the story
 		// new ChatGptMessage("system", 'Format your response as: {"responses":[{"response":"YOUR RESPONSE"}]}')
 		// );
 		try {
+			const endpoint = this._api.settings.ollamaUrl ? this._api.settings.ollamaUrl + '/v1/chat/completions' : this._endpoint;
+			const model = this._api.settings.ollamaUrl ? this._api.settings.ollamaModel : this._model;
 			const response = await axios.post(
-				this._endpoint,
+				endpoint,
 				{
-					model: this._model,
+					model: model,
 					messages: messages,
 				},
 				{
@@ -74,11 +76,18 @@ Each option should be qualitative, not a short sentence and will allow the story
 	}
 
 	private _processLatestMessage(latestMessage: string): ChatGptResponse[] {
-		const splitResponses = latestMessage.trim().split("\n");
 
-		const results: ChatGptResponse[] = splitResponses
-			.filter((resp) => resp.trim() !== "")
-			.map((resp) => ({ response: resp.replace(/^\d+\.\s*/, "").trim() }));
+		let results : ChatGptResponse[] = [];
+		if (this._api.settings.ollamaUrl) {
+			// formatting rules aren't ollama's strong suit, so we just return everything and let the user edit
+			results.push({response: latestMessage });
+		}
+		else {
+			const splitResponses = latestMessage.trim().split("\n");
+			results = splitResponses
+				.filter((resp) => resp.trim() !== "")
+				.map((resp) => ({ response: resp.replace(/^\d+\.\s*/, "").trim() }));
+		}
 
 		return results;
 	}

--- a/src/services/UpdaterService/components/UpdaterComponent.tsx
+++ b/src/services/UpdaterService/components/UpdaterComponent.tsx
@@ -32,6 +32,9 @@ function Upgrading(): React.ReactElement {
 		updater.updateVault().then(() => {
 			const settings: RpgManagerSettingsInterface = {
 				chatGptKey: undefined,
+				ollamaUrl: undefined,
+				ollamaModel: "llama3.1",
+				hasLLM: false,
 				templatesFolder: (api.settings as any).templateFolder,
 				assetsFolder: (api.settings as any).imagesFolder,
 				automaticMove: false,

--- a/src/settings/RpgManagerSettings.ts
+++ b/src/settings/RpgManagerSettings.ts
@@ -4,6 +4,9 @@ import { RpgManagerInterface } from "src/RpgManagerInterface";
 
 export interface RpgManagerSettingsInterface {
 	chatGptKey: string | undefined;
+	ollamaUrl: string | undefined;
+	ollamaModel: string;
+	hasLLM: boolean;
 	templatesFolder: string | undefined;
 	assetsFolder: string | undefined;
 	automaticMove: boolean;
@@ -17,6 +20,9 @@ export type PartialSettings = Partial<RpgManagerSettingsInterface>;
 
 export const rpgManagerDefaultSettings: RpgManagerSettingsInterface = {
 	chatGptKey: undefined,
+	ollamaUrl: undefined,
+	ollamaModel: "llama3.1",
+	hasLLM: false,
 	templatesFolder: undefined,
 	assetsFolder: undefined,
 	automaticMove: false,
@@ -128,9 +134,9 @@ export class RpgManagerSettings extends PluginSettingTab {
 				});
 			});
 
-		containerEl.createEl("h3", { text: "ChatGPT", cls: "mt-3" });
-		const ChatGPT = containerEl.createEl("p");
-		ChatGPT.appendText("Set up all the add-ons for the plugin. ");
+		containerEl.createEl("h3", { text: "AI Plugins", cls: "mt-3" });
+		const AIPlugins = containerEl.createEl("p");
+		AIPlugins.appendText("Set up all the add-ons for the plugin. ");
 		const ChatGPTWarning = containerEl.createEl("p");
 		ChatGPTWarning.appendChild(
 			createEl("span", {
@@ -140,14 +146,51 @@ export class RpgManagerSettings extends PluginSettingTab {
 		);
 
 		new Setting(containerEl)
-			.setName("OpenAI Key")
+			.setName("OpenAI/ChatGPT Key")
 			.setDesc("Insert your OpenAI key here.")
 			.addText((text) =>
 				text
 					.setPlaceholder("")
 					.setValue(this._plugin.settings.chatGptKey)
 					.onChange(async (value: string) => {
-						await this.saveSettings({ chatGptKey: value });
+						await this.saveSettings({
+							chatGptKey: value,
+							hasLLM: true
+						});
+					})
+			);
+
+			const OllamaWarning = containerEl.createEl("p");
+			OllamaWarning.appendChild(
+				createEl("span", {
+					text: "Please note: Ollama is an open-source LLM you can run on your own machine(s). See ollama.com for more information",
+					cls: "text-[--text-warning]",
+				})
+			);
+
+			new Setting(containerEl)
+			.setName("Ollama URL")
+			.setDesc("Insert the root URL of your local ollama server (eg. http://localhost:11434)")
+			.addText((text) =>
+				text
+					.setPlaceholder("http://localhost:11434")
+					.setValue(this._plugin.settings.ollamaUrl)
+					.onChange(async (value: string) => {
+						await this.saveSettings({
+							ollamaUrl: value,
+							hasLLM: true
+						});
+					})
+			);
+		new Setting(containerEl)
+			.setName("Ollama Model")
+			.setDesc("Enter the ollama model (eg. llama3.1)")
+			.addText((text) =>
+				text
+					.setPlaceholder("llama3.1")
+					.setValue(this._plugin.settings.ollamaModel)
+					.onChange(async (value: string) => {
+						await this.saveSettings({ ollamaModel: value });
 					})
 			);
 	}


### PR DESCRIPTION
[Ollama](https://ollama.com) is an open-source LLM with open models. Some of the larger models even rival ChatGpt4 accuracy. However, the smaller models are runnable on a home PC for only the cost of electricity.

Ollama also has a chatgpt-compatible api.

- Added settings for ollamaUrl & model as an alternative to chatgpt
- Modified output format assumptions and parsing of lists for ollama as output consistency isn't as strong as chatgpt
- Made a generic `hasLLM` flag in settings for (ollama || chatgpt)