### PR TITLE
Patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ In the next sections, we will delve deeper into other elements and how they rela
 
 An adventure is a significant component of a campaign, encompassing a series of events or challenges that have a distinct beginning and conclusion. Each adventure comprises multiple chapters, which help in structuring the narrative in a more organized manner. An adventure can be further organized into multiple chapters to streamline the storytelling process.
 
-An adventure serves as a pivotal building block within a campaign, functioning as a coherent narrative unit with a specific beginning and end. It normally encompasses a series of events, locations, and challenges that can be grouped together in a single narrative. For example, in the famed "Masks of Nyarlathotep" campaign for Call of Cthulhu, everything that happens in New York could be considered a single adventure.
+An adventure serves as a pivotal building block within a campaign, functioning as a coherent narrative unit. It normally encompasses a series of events, locations, and challenges. For example, in the famed "Masks of Nyarlathotep" campaign for Call of Cthulhu, everything that happens in New York could be considered a single adventure.
 
 **Attributes**
 

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ In the next sections, we will delve deeper into other elements and how they rela
 
 #### 3.3.2. Adventures
 
-An adventure is a significant component of a campaign, encompassing a series of events or challenges that have a distinct beginning and conclusion. Each adventure comprises multiple chapters, which help in structuring the narrative in a more organized manner. An adventure can be further organized into multiple chapters to streamline the storytelling process.
+An adventure serves as a coherent narrative unit within a campaign, encompassing a series of events or challenges that have a distinct beginning and conclusion. Each adventure comprises multiple chapters, which help in structuring the narrative and streamline the storytelling process.
 
-An adventure serves as a pivotal building block within a campaign, functioning as a coherent narrative unit. It normally encompasses a series of events, locations, and challenges. For example, in the famed "Masks of Nyarlathotep" campaign for Call of Cthulhu, everything that happens in New York could be considered a single adventure.
+An adventure normally encompasses a series of events, locations, and challenges. For example, in the famed "Masks of Nyarlathotep" campaign for Call of Cthulhu, everything that happens in New York could be considered a single adventure.
 
 **Attributes**
 

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ In the next sections, we will delve deeper into other elements and how they rela
 
 #### 3.3.2. Adventures
 
-An adventure is a significant component of a campaign, encompassing a series of events or challenges that have a distinct beginning and conclusion. For instance, in the well-known Call of Cthulhu campaign, "Masks of Nyarlathotep," all events transpiring in New York could be classified as a single adventure. Each adventure comprises multiple chapters, which help in structuring the narrative in a more organized manner.
+An adventure is a significant component of a campaign, encompassing a series of events or challenges that have a distinct beginning and conclusion. Each adventure comprises multiple chapters, which help in structuring the narrative in a more organized manner. An adventure can be further organized into multiple chapters to streamline the storytelling process.
 
-An adventure serves as a pivotal building block within a campaign, functioning as a coherent narrative unit with a specific beginning and end. It normally encompasses a series of events, locations od challenges that can be grouped together in a single narrative. For example, in the famed "Masks of Nyarlathotep" campaign for Call of Cthulhu, everything that happens in New York could be considered a single adventure. An adventure can be further organized into multiple chapters to streamline the storytelling process.
+An adventure serves as a pivotal building block within a campaign, functioning as a coherent narrative unit with a specific beginning and end. It normally encompasses a series of events, locations, and challenges that can be grouped together in a single narrative. For example, in the famed "Masks of Nyarlathotep" campaign for Call of Cthulhu, everything that happens in New York could be considered a single adventure.
 
 **Attributes**
 


### PR DESCRIPTION
I started editing the Adventure section because of a typo ("od") and then did several further edits after rereading and seeing a lot of repeated information across the two paragraphs.

The first paragraph now describes Adventures as a narrative feature, and the second expresses the elements you can expect to find in an adventure.

The only remaining repetition is about how adventures contain events and challenges. This seemed relevant to both paragraphs. I tried to make as few opinionated edits as possible so you'd find the PR the most useful, but I do encourage you to possibly combine the two paragraphs however you see fit before merging.